### PR TITLE
Update route.go

### DIFF
--- a/config/route.go
+++ b/config/route.go
@@ -23,6 +23,9 @@ func (r *Route) MessagePatternTemplate() *template.Template {
 
 // LoadMessagePattern is called after config is loaded, and verified patterns are valid
 func (r *Route) LoadMessagePattern() error {
+	if !r.IsEnabled {
+		return nil
+	}
 	var err error
 	r.messagePatternTemplate, err = template.New("root").Parse(r.MessagePattern)
 	if err != nil {


### PR DESCRIPTION
Add check for IsEnabled from the routes section of config file


When I set enabled = false for a telenet.route to discord in the talkeq.conf file, it didn't have any effect.  Looking at the go code, that is because there is never a check in this file to return nil if it is not enabled.